### PR TITLE
Release/alm release 4.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<azure.version>2.1.6</azure.version>
 		<spring-cloud-services.version>2.1.4.RELEASE</spring-cloud-services.version>
 		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
-		<vaadin.version>13.0.10</vaadin.version>
+		<vaadin.version>14.6.8</vaadin.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Bumps vaadin-bom from 13.0.10 to 14.6.8.

---
updated-dependencies:
- dependency-name: com.vaadin:vaadin-bom
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>